### PR TITLE
Allow user to cancel observation from observation detail page.

### DIFF
--- a/podman/requirements.txt
+++ b/podman/requirements.txt
@@ -94,7 +94,6 @@ PyYAML==6.0.1
 redis==5.0.1
 requests==2.31.0
 roman-numerals-py==3.1.0
-scikit-learn==1.8.0
 scipy==1.11.4
 scramp==1.4.5
 SecretStorage==3.3.3

--- a/sso_tom/.env.example
+++ b/sso_tom/.env.example
@@ -70,9 +70,14 @@ USE_FINK=False
 # IF USE_FINK is True the following are (REQUIRED) and need to be uncommented.
 # FINK_CREDENTIAL_USERNAME=FinkUsername(CHANGEME)
 # FINK_CREDENTIAL_GROUP_ID=FinkGroupID(CHANGEME)
-# FINK_CREDENTIAL_URL=FinkLivestreamURL(CHANGEME)
 # FINK_MAX_POLL_NUMBER=2
 # FINK_TIMEOUT=10
+
+# Fink ZTF url
+# FINK_CREDENTIAL_URL=FinkLivestreamURL(CHANGEME)
+
+# Fink LSST url
+# FINK_CREDENTIAL_LSST_URL=FinkLivestreamURL(CHANGEME)
 
 #######################################################################################################
 

--- a/sso_tom/sso_tom/settings_local.py
+++ b/sso_tom/sso_tom/settings_local.py
@@ -73,9 +73,13 @@ ZTF_TOPICS = [
 ]
 
 LSST_TOPICS = [
-    "fink_extragalactic_candidate_lsst",
-    "fink_cataloged_lsst",
+    "fink_early_snia_candidate_lsst",
+    "fink_extragalactic_lt20mag_candidate_lsst",
+    "fink_extragalactic_new_candidate_lsst",
+    "fink_good_quality_lsst",
+    "fink_hostless_candidate_lsst",
     "fink_in_tns_lsst",
+    "fink_sn_near_galaxy_candidate_lsst",
 ]
 
 TOPICS = []

--- a/sso_tom/templates/tom_observations/observationrecord_detail.html
+++ b/sso_tom/templates/tom_observations/observationrecord_detail.html
@@ -13,8 +13,7 @@
             <p>{% update_observation_id_form object %}</p>
             {% endif %}
             <p class="my-auto"><strong>Observation ID:</strong> {{ object.observation_id }}</p>
-            <p class="my-auto"><strong>Created:</strong> {{ object.created }} <strong>Modified:</strong> {{
-                object.modified }}</p>
+            <p class="my-auto"><strong>Created:</strong> {{ object.created }} <strong>Modified:</strong> {{ object.modified }}</p>
             <p class="my-auto"><strong>Status:</strong> {{ object.status }}</p>
         </div>
         <p></p>
@@ -26,10 +25,13 @@
     </div>
 </div>
 <div class="row">
-    <div class="col-md-4">
+    <div class="column">
         {% observationtemplate_from_record object %}
-        {% observation_cancel object %}
-        <p></p>
+        <a href="{% url 'observations:detail' observationrecord.id %}cancel" class="btn btn-outline-primary">Cancel Observation</a>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-4">
         <h4>Request Parameters</h4><br>
         <dl class="row">
             {% for k,v in object.parameters.items %}

--- a/sso_tom/templates/tom_observations/observationrecord_detail.html
+++ b/sso_tom/templates/tom_observations/observationrecord_detail.html
@@ -13,7 +13,8 @@
             <p>{% update_observation_id_form object %}</p>
             {% endif %}
             <p class="my-auto"><strong>Observation ID:</strong> {{ object.observation_id }}</p>
-            <p class="my-auto"><strong>Created:</strong> {{ object.created }} <strong>Modified:</strong> {{ object.modified }}</p>
+            <p class="my-auto"><strong>Created:</strong> {{ object.created }} <strong>Modified:</strong> {{
+                object.modified }}</p>
             <p class="my-auto"><strong>Status:</strong> {{ object.status }}</p>
         </div>
         <p></p>
@@ -27,13 +28,14 @@
 <div class="row">
     <div class="col-md-4">
         {% observationtemplate_from_record object %}
+        {% observation_cancel object %}
         <p></p>
         <h4>Request Parameters</h4><br>
         <dl class="row">
             {% for k,v in object.parameters.items %}
             <dt class="col-sm-6">{{ k }}</dt>
             <dd class="col-sm-6">{{ v }}</dt>
-            {% endfor %}
+                {% endfor %}
         </dl>
     </div>
 </div>

--- a/sso_tom/templates/tom_observations/partials/observation_cancel.html
+++ b/sso_tom/templates/tom_observations/partials/observation_cancel.html
@@ -1,0 +1,2 @@
+<a href="{% url 'tom_observations:detail' observation.id %}/cancel" class="btn  btn-outline-primary">Cancel
+    Observation</a>

--- a/sso_tom/templates/tom_observations/partials/observation_cancel.html
+++ b/sso_tom/templates/tom_observations/partials/observation_cancel.html
@@ -1,2 +1,0 @@
-<a href="{% url 'tom_observations:detail' observation.id %}/cancel" class="btn  btn-outline-primary">Cancel
-    Observation</a>


### PR DESCRIPTION
- Allows user to cancel observation from observation detail page.
- Sets "No observations" as a terminal state
- Black formatting on files
- Fink settings example update
- Does NOT fix removing observations from observation list page.

@clidman partial fix for #5 