### PR TITLE
Generate fink alert streams topic list automatically

### DIFF
--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -33,7 +33,7 @@ RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh | b
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-RUN pip install --no-cache-dir tom_fink
+# RUN pip install --no-cache-dir tom_fink
 
 # Code directory is now volume mounted.
 # COPY . /code

--- a/podman/requirements.txt
+++ b/podman/requirements.txt
@@ -45,7 +45,7 @@ docutils==0.21.2
 dramatiq==1.15.0
 executing==2.2.0
 fastavro==1.9.4
-fink-client==9.0
+fink-client==10.1
 fits2image==0.4.7
 gcn-kafka==0.3.3
 gevent==23.9.1

--- a/sso_tom/sso_alerts/forms.py
+++ b/sso_tom/sso_alerts/forms.py
@@ -1,5 +1,5 @@
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit, Reset, Layout, Field, HTML
+from crispy_forms.layout import HTML, Field, Layout, Reset, Submit
 from django import forms
 from django.conf import settings
 from django.utils.safestring import mark_safe
@@ -24,11 +24,7 @@ class AlertStreamsForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["topic"] = forms.ChoiceField(
-            choices=[(topic, topic) for topic in settings.TOPICS],
-            initial="fink_sso_fink_candidates_ztf",
-            label=mark_safe(
-                'Topic (<small> \'Deployed\' ones from: <a target="_blank" href="https://fink-broker.readthedocs.io/en/latest/science/filters/#available-topics">Available Topics</a></small>)'
-            ),
+            choices=[(topic, topic) for topic in settings.TOPICS]
         )
         self.helper = FormHelper(self)
         self.helper.layout = Layout(

--- a/sso_tom/sso_tom/settings.py
+++ b/sso_tom/sso_tom/settings.py
@@ -69,8 +69,10 @@ INSTALLED_APPS = [
 # This is a temporary solution until I decide if the tom_fink import via .gitmodules should be replaced with a required package.
 # Answer is probably yes
 USE_FINK = dotenv("USE_FINK", default="False", cast=bool)
-if USE_FINK:
-    INSTALLED_APPS.append("tom_fink")
+
+# Unused because requires a lower version than fink-client 10.1
+# if USE_FINK:
+#     INSTALLED_APPS.append("tom_fink")
 
 
 SITE_ID = 1
@@ -295,8 +297,9 @@ TOM_ALERT_CLASSES = [
     # "tom_alerts.brokers.fink.FinkBroker",
 ]
 
-if USE_FINK:
-    TOM_ALERT_CLASSES.append("tom_fink.fink.FinkBroker")
+# Unused because requires a lower version than fink-client 10.1
+# if USE_FINK:
+#     TOM_ALERT_CLASSES.append("tom_fink.fink.FinkBroker")
 
 BROKERS = {
     "TNS": {

--- a/sso_tom/sso_tom/settings_local.py
+++ b/sso_tom/sso_tom/settings_local.py
@@ -55,42 +55,43 @@ ARCHIVE_2M3_RESULTS = dotenv("2M3_ARCHIVE_RESULTS", default=None)
 
 
 ### ALERT STREAMS SETTINGS ###
+TOPICS = []
 
 #### FINK SETTINGS ####
 USE_FINK = bool(strtobool(dotenv("USE_FINK", default="False")))
 
-# To add a new topic - add one here.
-ZTF_TOPICS = [
-    "fink_early_sn_candidates_ztf",
-    "fink_sn_candidates_ztf",
-    "fink_sso_ztf_candidates_ztf",
-    "fink_sso_fink_candidates_ztf",
-    "fink_kn_candidates_ztf",
-    "fink_early_kn_candidates_ztf",
-    "fink_rate_based_kn_candidates_ztf",
-    "fink_microlensing_candidates_ztf",
-    "fink_blazar_ztf",
-]
-
-LSST_TOPICS = [
-    "fink_early_snia_candidate_lsst",
-    "fink_extragalactic_lt20mag_candidate_lsst",
-    "fink_extragalactic_new_candidate_lsst",
-    "fink_good_quality_lsst",
-    "fink_hostless_candidate_lsst",
-    "fink_in_tns_lsst",
-    "fink_sn_near_galaxy_candidate_lsst",
-]
-
-TOPICS = []
-
-if dotenv("FINK_CREDENTIAL_URL", default=None) is not None:
-    TOPICS = TOPICS + ZTF_TOPICS
-
-if dotenv("FINK_CREDENTIAL_LSST_URL", default=None) is not None:
-    TOPICS = TOPICS + LSST_TOPICS
-
 if USE_FINK:
+    from fink_client.consumer import AlertConsumer
+
+    config = {
+        "username": dotenv(
+            "FINK_CREDENTIAL_USERNAME",
+            default="set FINK_CREDENTIAL_USERNAME value in environment",
+        ),
+        "group.id": dotenv(
+            "FINK_CREDENTIAL_GROUP_ID",
+            default="set FINK_CREDENTIAL_GROUP_ID value in environment",
+        ),
+    }
+
+    if dotenv("FINK_CREDENTIAL_URL", default=None) is not None:
+        config["bootstrap.servers"] = dotenv(
+            "FINK_CREDENTIAL_URL",
+            default="set FINK_CREDENTIAL_URL value in environment",
+        )
+        consumer = AlertConsumer(survey="ztf", topics=["pie"], config=config)
+        ZTF_TOPICS = consumer.available_topics(service="livestream").sort()  # type: ignore fink-client has incorrect return type
+        TOPICS = TOPICS + ZTF_TOPICS
+
+    if dotenv("FINK_CREDENTIAL_LSST_URL", default=None) is not None:
+        config["bootstrap.servers"] = dotenv(
+            "FINK_CREDENTIAL_LSST_URL",
+            default="set FINK_CREDENTIAL_LSST_URL value in environment",
+        )
+        consumer = AlertConsumer(survey="lsst", topics=["pie"], config=config)
+        LSST_TOPICS = consumer.available_topics(service="livestream").sort()  # type: ignore fink-client has incorrect return type
+        TOPICS = TOPICS + LSST_TOPICS
+
     if dotenv("FINK_CREDENTIAL_URL", default=None) is not None:
         finkZTFTopics = [
             {

--- a/sso_tom/sso_tom/settings_local.py
+++ b/sso_tom/sso_tom/settings_local.py
@@ -80,8 +80,9 @@ if USE_FINK:
             default="set FINK_CREDENTIAL_URL value in environment",
         )
         consumer = AlertConsumer(survey="ztf", topics=["pie"], config=config)
-        ZTF_TOPICS = consumer.available_topics(service="livestream").sort()  # type: ignore fink-client has incorrect return type
-        TOPICS = TOPICS + ZTF_TOPICS
+        ZTF_TOPICS = consumer.available_topics(service="livestream")
+        ZTF_TOPICS.sort()  # type: ignore fink-client has incorrect return type
+        TOPICS = TOPICS + ZTF_TOPICS  # type: ignore fink-client has incorrect return type
 
     if dotenv("FINK_CREDENTIAL_LSST_URL", default=None) is not None:
         config["bootstrap.servers"] = dotenv(
@@ -89,8 +90,9 @@ if USE_FINK:
             default="set FINK_CREDENTIAL_LSST_URL value in environment",
         )
         consumer = AlertConsumer(survey="lsst", topics=["pie"], config=config)
-        LSST_TOPICS = consumer.available_topics(service="livestream").sort()  # type: ignore fink-client has incorrect return type
-        TOPICS = TOPICS + LSST_TOPICS
+        LSST_TOPICS = consumer.available_topics(service="livestream")
+        LSST_TOPICS.sort()  # type: ignore fink-client has incorrect return type
+        TOPICS = TOPICS + LSST_TOPICS  # type: ignore fink-client has incorrect return type
 
     if dotenv("FINK_CREDENTIAL_URL", default=None) is not None:
         finkZTFTopics = [


### PR DESCRIPTION
Generate fink alert streams topic list automatically using available topics function from kafka.

Closes #32 , but creates new issue as tom_fink doesn't support fink_client 10.1 yet.